### PR TITLE
Harden news fetching lifecycle

### DIFF
--- a/src/google_news_trends_mcp/news.py
+++ b/src/google_news_trends_mcp/news.py
@@ -99,13 +99,15 @@ class BrowserManager(AsyncContextDecorator):
         return _browser_context_cm()
 
     async def __aenter__(self):
-        type(self)._class_contexts += 1
+        async with type(self)._lock:
+            type(self)._class_contexts += 1
         return self
 
     async def __aexit__(self, *exc):
-        type(self)._class_contexts -= 1
-        if type(self)._class_contexts == 0:
-            await self._shutdown()
+        async with type(self)._lock:
+            type(self)._class_contexts -= 1
+            if type(self)._class_contexts == 0:
+                await self._shutdown()
         return False
 
 

--- a/src/google_news_trends_mcp/news.py
+++ b/src/google_news_trends_mcp/news.py
@@ -104,7 +104,8 @@ class BrowserManager(AsyncContextDecorator):
 
     async def __aexit__(self, *exc):
         type(self)._class_contexts -= 1
-        await self._shutdown()
+        if type(self)._class_contexts == 0:
+            await self._shutdown()
         return False
 
 
@@ -115,7 +116,7 @@ async def download_article_with_playwright(url) -> newspaper.Article | None:
     async with BrowserManager.browser_context() as context:
         try:
             page = await context.new_page()
-            await page.goto(url, wait_until="domcontentloaded")
+            await page.goto(url, wait_until="domcontentloaded", timeout=30_000)
             await asyncio.sleep(2)  # Wait for the page to load completely
             content = await page.content()
             article = newspaper.article(url, input_html=content)
@@ -133,7 +134,7 @@ def download_article_with_scraper(url) -> newspaper.Article | None:
         logger.debug(f"Error downloading article with newspaper from {url}\n {e.args}")
         try:
             # Retry with cloudscraper
-            response = scraper.get(url)
+            response = scraper.get(url, timeout=30)
             if response.status_code < 400:
                 article = newspaper.article(url, input_html=response.text)
             else:
@@ -155,7 +156,7 @@ def decode_url(url: str) -> str:
                 logger.debug("Failed to decode Google News RSS link:")
         except Exception as err:
             logger.warning(f"Error while decoding url {url}\n {err.args}")
-    return ""
+    return url
 
 
 async def download_article(url: str) -> newspaper.Article | None:

--- a/src/google_news_trends_mcp/server.py
+++ b/src/google_news_trends_mcp/server.py
@@ -166,7 +166,7 @@ async def get_news_by_keyword(
     ctx: Context,
     keyword: Annotated[str, Field(description="Search term to find articles.")],
     period: Annotated[int, Field(description="Number of days to look back for articles.", ge=1)] = 7,
-    max_results: Annotated[int, Field(description="Maximum number of results to return.", ge=1)] = 10,
+    max_results: Annotated[int, Field(description="Maximum number of results to return.", ge=1, le=25)] = 10,
     full_data: Annotated[
         bool,
         Field(
@@ -202,7 +202,7 @@ async def get_news_by_location(
     ctx: Context,
     location: Annotated[str, Field(description="Name of city/state/country.")],
     period: Annotated[int, Field(description="Number of days to look back for articles.", ge=1)] = 7,
-    max_results: Annotated[int, Field(description="Maximum number of results to return.", ge=1)] = 10,
+    max_results: Annotated[int, Field(description="Maximum number of results to return.", ge=1, le=25)] = 10,
     full_data: Annotated[
         bool,
         Field(
@@ -235,7 +235,7 @@ async def get_news_by_topic(
     ctx: Context,
     topic: Annotated[str, Field(description="Topic to search for articles.")],
     period: Annotated[int, Field(description="Number of days to look back for articles.", ge=1)] = 7,
-    max_results: Annotated[int, Field(description="Maximum number of results to return.", ge=1)] = 10,
+    max_results: Annotated[int, Field(description="Maximum number of results to return.", ge=1, le=25)] = 10,
     full_data: Annotated[
         bool,
         Field(
@@ -267,7 +267,7 @@ async def get_news_by_topic(
 async def get_top_news(
     ctx: Context,
     period: Annotated[int, Field(description="Number of days to look back for top articles.", ge=1)] = 3,
-    max_results: Annotated[int, Field(description="Maximum number of results to return.", ge=1)] = 10,
+    max_results: Annotated[int, Field(description="Maximum number of results to return.", ge=1, le=25)] = 10,
     full_data: Annotated[
         bool,
         Field(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,7 @@
 import pytest
+from contextlib import asynccontextmanager
 from fastmcp import Client
+from fastmcp.exceptions import ToolError
 from google_news_trends_mcp.server import mcp
 from google_news_trends_mcp import news
 from google_news_trends_mcp.news import (
@@ -91,6 +93,34 @@ def test_scraper_fallback_has_timeout(monkeypatch):
 
     assert news.download_article_with_scraper("https://example.com/news") is None
     assert seen_timeouts == [30]
+
+
+async def test_playwright_navigation_has_timeout(monkeypatch):
+    seen_timeouts = []
+
+    class Page:
+        async def goto(self, *args, **kwargs):
+            seen_timeouts.append(kwargs["timeout"])
+            raise RuntimeError("navigation failed")
+
+    class Context:
+        async def new_page(self):
+            return Page()
+
+    @asynccontextmanager
+    async def fake_browser_context():
+        yield Context()
+
+    monkeypatch.setattr(BrowserManager, "browser_context", classmethod(lambda cls: fake_browser_context()))
+
+    assert await download_article_with_playwright("https://example.com/news") is None
+    assert seen_timeouts == [30_000]
+
+
+async def test_news_tools_reject_unbounded_max_results(mcp_server):
+    async with Client(mcp_server) as client:
+        with pytest.raises(ToolError, match="less than or equal to 25"):
+            await client.call_tool("get_top_news", {"max_results": 26})
 
 
 async def test_get_news_by_keyword(mcp_server):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 import pytest
 from fastmcp import Client
 from google_news_trends_mcp.server import mcp
+from google_news_trends_mcp import news
 from google_news_trends_mcp.news import (
     download_article_with_playwright,
     save_article_to_json,
@@ -39,6 +40,57 @@ async def test_download_article():
 
 def _articles(result):
     return result.structured_content.get("result", [])
+
+
+def test_decode_url_preserves_direct_publisher_url():
+    url = "https://example.com/news/story"
+
+    assert news.decode_url(url) == url
+
+
+def test_decode_url_falls_back_when_google_news_decode_fails(monkeypatch):
+    url = "https://news.google.com/rss/articles/example"
+    monkeypatch.setattr(news, "gnewsdecoder", lambda _: {"status": False})
+
+    assert news.decode_url(url) == url
+
+
+async def test_browser_manager_shuts_down_after_final_context(monkeypatch):
+    shutdown_calls = []
+
+    async def fake_shutdown(cls):
+        shutdown_calls.append(True)
+
+    monkeypatch.setattr(BrowserManager, "_shutdown", classmethod(fake_shutdown))
+
+    async with BrowserManager():
+        async with BrowserManager():
+            assert BrowserManager._class_contexts == 2
+        assert BrowserManager._class_contexts == 1
+        assert shutdown_calls == []
+
+    assert BrowserManager._class_contexts == 0
+    assert shutdown_calls == [True]
+
+
+def test_scraper_fallback_has_timeout(monkeypatch):
+    seen_timeouts = []
+
+    def fail_newspaper_article(*args, **kwargs):
+        raise RuntimeError("download failed")
+
+    class Response:
+        status_code = 500
+
+    def fake_get(url, timeout):
+        seen_timeouts.append(timeout)
+        return Response()
+
+    monkeypatch.setattr(news.newspaper, "article", fail_newspaper_article)
+    monkeypatch.setattr(news.scraper, "get", fake_get)
+
+    assert news.download_article_with_scraper("https://example.com/news") is None
+    assert seen_timeouts == [30]
 
 
 async def test_get_news_by_keyword(mcp_server):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from contextlib import asynccontextmanager
 from fastmcp import Client
@@ -73,6 +74,40 @@ async def test_browser_manager_shuts_down_after_final_context(monkeypatch):
 
     assert BrowserManager._class_contexts == 0
     assert shutdown_calls == [True]
+
+
+async def test_browser_manager_waits_for_shutdown_before_reentering(monkeypatch):
+    shutdown_started = asyncio.Event()
+    finish_shutdown = asyncio.Event()
+    entry_attempted = asyncio.Event()
+    entered = asyncio.Event()
+
+    async def fake_shutdown(cls):
+        shutdown_started.set()
+        await finish_shutdown.wait()
+
+    monkeypatch.setattr(BrowserManager, "_shutdown", classmethod(fake_shutdown))
+
+    manager = BrowserManager()
+    await manager.__aenter__()
+    exit_task = asyncio.create_task(manager.__aexit__(None, None, None))
+    await shutdown_started.wait()
+
+    async def enter_next_context():
+        entry_attempted.set()
+        async with BrowserManager():
+            entered.set()
+
+    enter_task = asyncio.create_task(enter_next_context())
+    try:
+        await entry_attempted.wait()
+        assert not entered.is_set()
+    finally:
+        finish_shutdown.set()
+        await asyncio.gather(exit_task, enter_task)
+
+    assert entered.is_set()
+    assert BrowserManager._class_contexts == 0
 
 
 def test_scraper_fallback_has_timeout(monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve direct publisher URLs and fall back when Google News URL decoding fails
- keep the shared Playwright browser alive until its final manager context exits
- bound browser and scraper requests, and cap MCP news result counts at 25
- add offline regressions for URL handling, browser lifetime, navigation and scraper timeouts, and request-limit validation

## Validation
- `python3 -m ruff check .`
- `python3 -m pytest tests/test_server.py -k 'decode_url or browser_manager_shuts_down or scraper_fallback or playwright_navigation or unbounded_max_results'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f66c2-ddb9-7e8b-ab52-e89ea28a207e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f66c2-ddb9-7e8b-ab52-e89ea28a207e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

