### PR TITLE
Add pull request CI for lint and offline tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Lint & offline tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Install dependencies
+        run: uv sync --group dev
+      - name: Ruff
+        run: uv run ruff check src tests
+      - name: Offline / smoke tests
+        # Skip live Google News/Trends and external-site integration tests.
+        # Offline hardening tests (decode_url, browser lifetime, timeouts, caps)
+        # are selected automatically when present.
+        run: >-
+          uv run pytest -v
+          -k "not (get_news_by_ or get_top_news or get_trending_terms or download_article)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `.github/workflows/ci.yml` to run on pushes to `main` and all pull requests
- Install with `uv sync --group dev`, run `ruff check`, then offline/smoke pytest
- Exclude live Google News/Trends integration tests via pytest `-k` so CI stays deterministic

## Why
Today only the tag-triggered release workflow runs a smoke test. PR CI catches lint and offline regressions earlier, and already picks up the offline tests from #6.

Rebased onto current `main` (includes #6 / v0.2.10).

## Validation
- Locally: `uv run ruff check src tests`
- Locally: `uv run pytest -v -k "not (get_news_by_ or get_top_news or get_trending_terms or download_article)"`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ee85e9d-c27f-4471-a73b-2377f1e87498?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ee85e9d-c27f-4471-a73b-2377f1e87498&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

