### PR TITLE
Harden trends sorting, LLM summarize, and CLI saves

### DIFF
--- a/src/google_news_trends_mcp/cli.py
+++ b/src/google_news_trends_mcp/cli.py
@@ -25,16 +25,17 @@ def cli():
 @click.option(
     "--max-results",
     "max_results",
-    type=int,
+    type=click.IntRange(1, 25),
     default=10,
-    help="Maximum number of results to return.",
+    help="Maximum number of results to return (1-25).",
 )
 @click.option("--no-nlp", is_flag=True, default=False, help="Disable NLP processing for articles.")
-def keyword(keyword, period, max_results, no_nlp):
+@click.option("--save", is_flag=True, default=False, help="Save each article to a JSON file in the current directory.")
+def keyword(keyword, period, max_results, no_nlp, save):
     @BrowserManager()
     async def _keyword():
         articles = await get_news_by_keyword(keyword, period=period, max_results=max_results, nlp=not no_nlp)
-        print_articles(articles)
+        print_articles(articles, save=save)
         logger.info(f"Found {len(articles)} articles for keyword '{keyword}'.")
 
     asyncio.run(_keyword())
@@ -46,16 +47,17 @@ def keyword(keyword, period, max_results, no_nlp):
 @click.option(
     "--max-results",
     "max_results",
-    type=int,
+    type=click.IntRange(1, 25),
     default=10,
-    help="Maximum number of results to return.",
+    help="Maximum number of results to return (1-25).",
 )
 @click.option("--no-nlp", is_flag=True, default=False, help="Disable NLP processing for articles.")
-def location(location, period, max_results, no_nlp):
+@click.option("--save", is_flag=True, default=False, help="Save each article to a JSON file in the current directory.")
+def location(location, period, max_results, no_nlp, save):
     @BrowserManager()
     async def _location():
         articles = await get_news_by_location(location, period=period, max_results=max_results, nlp=not no_nlp)
-        print_articles(articles)
+        print_articles(articles, save=save)
         logger.info(f"Found {len(articles)} articles for location '{location}'.")
 
     asyncio.run(_location())
@@ -67,16 +69,17 @@ def location(location, period, max_results, no_nlp):
 @click.option(
     "--max-results",
     "max_results",
-    type=int,
+    type=click.IntRange(1, 25),
     default=10,
-    help="Maximum number of results to return.",
+    help="Maximum number of results to return (1-25).",
 )
 @click.option("--no-nlp", is_flag=True, default=False, help="Disable NLP processing for articles.")
-def topic(topic, period, max_results, no_nlp):
+@click.option("--save", is_flag=True, default=False, help="Save each article to a JSON file in the current directory.")
+def topic(topic, period, max_results, no_nlp, save):
     @BrowserManager()
     async def _topic():
         articles = await get_news_by_topic(topic, period=period, max_results=max_results, nlp=not no_nlp)
-        print_articles(articles)
+        print_articles(articles, save=save)
         logger.info(f"Found {len(articles)} articles for topic '{topic}'.")
 
     asyncio.run(_topic())
@@ -107,22 +110,23 @@ def trending(geo, full_data):
 @click.option(
     "--max-results",
     "max_results",
-    type=int,
+    type=click.IntRange(1, 25),
     default=10,
-    help="Maximum number of results to return.",
+    help="Maximum number of results to return (1-25).",
 )
 @click.option("--no-nlp", is_flag=True, default=False, help="Disable NLP processing for articles.")
-def top(period, max_results, no_nlp):
+@click.option("--save", is_flag=True, default=False, help="Save each article to a JSON file in the current directory.")
+def top(period, max_results, no_nlp, save):
     @BrowserManager()
     async def _top():
         articles = await get_top_news(max_results=max_results, period=period, nlp=not no_nlp)
-        print_articles(articles)
+        print_articles(articles, save=save)
         logger.info(f"Found {len(articles)} top articles.")
 
     asyncio.run(_top())
 
 
-def print_articles(articles):
+def print_articles(articles, save: bool = False):
     for article in articles:
         logger.info(f"Title: {article.title}")
         logger.info(f"URL: {article.original_url}")
@@ -130,7 +134,8 @@ def print_articles(articles):
         logger.info(f"Publish Date: {article.publish_date}")
         logger.info(f"Top Image: {article.top_image}")
         logger.info(f"Summary: {article.summary}\n")
-        save_article_to_json(article)
+        if save:
+            save_article_to_json(article)
 
 
 if __name__ == "__main__":

--- a/src/google_news_trends_mcp/news.py
+++ b/src/google_news_trends_mcp/news.py
@@ -280,6 +280,27 @@ async def get_news_by_topic(
     return await process_gnews_articles(gnews_articles, nlp=nlp, report_progress=report_progress)
 
 
+def parse_trend_volume(volume: Optional[str]) -> int:
+    """Parse Google Trends volume strings like '500+', '10K+', '1.2M' into ints."""
+    raw = (volume or "").strip().upper().rstrip("+")
+    if not raw:
+        return 0
+    multiplier = 1
+    if raw.endswith("K"):
+        multiplier = 1_000
+        raw = raw[:-1]
+    elif raw.endswith("M"):
+        multiplier = 1_000_000
+        raw = raw[:-1]
+    elif raw.endswith("B"):
+        multiplier = 1_000_000_000
+        raw = raw[:-1]
+    try:
+        return int(float(raw) * multiplier)
+    except ValueError:
+        return 0
+
+
 @overload
 async def get_trending_terms(geo: str = "US", full_data: Literal[False] = False) -> list[dict[str, str]]: ...
 
@@ -294,7 +315,7 @@ async def get_trending_terms(geo: str = "US", full_data: bool = False) -> list[d
     """
     try:
         trends = cast(list[TrendKeywordLite], tr.trending_now_by_rss(geo=geo))
-        trends = sorted(trends, key=lambda tt: int(tt.volume[:-1]), reverse=True)
+        trends = sorted(trends, key=lambda tt: parse_trend_volume(tt.volume), reverse=True)
         if not full_data:
             return [{"keyword": trend.keyword, "volume": trend.volume} for trend in trends]
         return trends

--- a/src/google_news_trends_mcp/server.py
+++ b/src/google_news_trends_mcp/server.py
@@ -128,9 +128,10 @@ def set_newspaper_article_fields(full_data: bool = False):
         ]
 
 
-async def llm_summarize_article(article: Article, ctx: Context) -> None:
+async def llm_summarize_article(article: Article, ctx: Context, max_chars: int = 4_000) -> None:
     if article.text:
-        prompt = f"Please provide a concise summary of the following news article:\n\n{article.text}"
+        article_text = article.text if len(article.text) <= max_chars else article.text[:max_chars] + "\n..."
+        prompt = f"Please provide a concise summary of the following news article:\n\n{article_text}"
         response = await ctx.sample(prompt)
         if isinstance(response, TextContent):
             if not response.text:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -158,6 +158,59 @@ async def test_news_tools_reject_unbounded_max_results(mcp_server):
             await client.call_tool("get_top_news", {"max_results": 26})
 
 
+def test_parse_trend_volume_handles_common_formats():
+    assert news.parse_trend_volume("500+") == 500
+    assert news.parse_trend_volume("2000+") == 2000
+    assert news.parse_trend_volume("10K+") == 10_000
+    assert news.parse_trend_volume("1.5M") == 1_500_000
+    assert news.parse_trend_volume("") == 0
+    assert news.parse_trend_volume("n/a") == 0
+
+
+async def test_get_trending_terms_sorts_without_dropping_bad_volumes(monkeypatch):
+    class FakeTrend:
+        def __init__(self, keyword, volume):
+            self.keyword = keyword
+            self.volume = volume
+
+    fake_trends = [
+        FakeTrend("low", "100+"),
+        FakeTrend("bad", "??"),
+        FakeTrend("high", "10K+"),
+    ]
+    monkeypatch.setattr(news.tr, "trending_now_by_rss", lambda geo: fake_trends)
+
+    result = await news.get_trending_terms(geo="US", full_data=False)
+    assert [item["keyword"] for item in result] == ["high", "low", "bad"]
+
+
+async def test_llm_summarize_article_truncates_long_text():
+    from google_news_trends_mcp.server import llm_summarize_article
+    from mcp.types import TextContent
+
+    class FakeArticle:
+        text = "x" * 5_000
+        summary = None
+
+    prompts = []
+
+    class FakeContext:
+        async def sample(self, prompt):
+            prompts.append(prompt)
+            return TextContent(type="text", text="short summary")
+
+        async def warning(self, message):
+            pass
+
+    article = FakeArticle()
+    await llm_summarize_article(article, FakeContext(), max_chars=100)
+    assert len(prompts) == 1
+    assert prompts[0].endswith("\n...")
+    assert "x" * 100 in prompts[0]
+    assert "x" * 101 not in prompts[0]
+    assert article.summary == "short summary"
+
+
 async def test_get_news_by_keyword(mcp_server):
     async with Client(mcp_server) as client:
         params = {"keyword": "AI", "period": 3, "max_results": 2}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Parse Google Trends volume strings safely (`500+`, `10K+`, `1.5M`, etc.) so a single bad value cannot empty the entire trends response
- Truncate article text to 4k chars before LLM sampling to limit prompt size / cost / injection surface
- Make CLI JSON file writing opt-in with `--save` (previously always wrote to CWD)
- Cap CLI `--max-results` to `1..25` to match MCP bounds from #6
- Add offline unit tests for volume parsing, sort stability, and summarize truncation

## Why
High outcome / low code: trends currently fail closed to `[]` on any parse error, LLM summarize can dump entire article bodies into sampling prompts, and the CLI surprisingly writes JSON files on every run.

Rebased onto current `main` (includes #6 / v0.2.10).

## Validation
- `uv run ruff check src tests`
- `uv run pytest tests/test_server.py -k 'parse_trend_volume or get_trending_terms_sorts or llm_summarize or test_smoke'`
- `uv run google-news-trends top --help` shows `--save` and `--max-results` range

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ee85e9d-c27f-4471-a73b-2377f1e87498?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ee85e9d-c27f-4471-a73b-2377f1e87498&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

