### PR TITLE
Fail soft on Playwright browser startup errors

### DIFF
--- a/src/google_news_trends_mcp/news.py
+++ b/src/google_news_trends_mcp/news.py
@@ -68,7 +68,7 @@ class BrowserManager(AsyncContextDecorator):
                         cls._browser = await cls._playwright.chromium.launch(headless=True)
                     except Exception as e:
                         logger.critical("Browser startup failed", exc_info=e)
-                        raise SystemExit(1)
+                        raise RuntimeError("Browser startup failed") from e
         return cast(Browser, cls._browser)
 
     @classmethod

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -158,6 +158,20 @@ async def test_news_tools_reject_unbounded_max_results(mcp_server):
             await client.call_tool("get_top_news", {"max_results": 26})
 
 
+async def test_browser_startup_failure_raises_runtime_error(monkeypatch):
+    BrowserManager._browser = None
+    BrowserManager._playwright = None
+
+    class FakePlaywright:
+        async def start(self):
+            raise OSError("chromium missing")
+
+    monkeypatch.setattr(news, "async_playwright", lambda: FakePlaywright())
+
+    with pytest.raises(RuntimeError, match="Browser startup failed"):
+        await BrowserManager._get_browser()
+
+
 async def test_get_news_by_keyword(mcp_server):
     async with Client(mcp_server) as client:
         params = {"keyword": "AI", "period": 3, "max_results": 2}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace `SystemExit(1)` on Playwright browser startup failure with `RuntimeError`, so a missing Chromium install cannot kill the whole MCP process
- Add an offline regression for that fail-soft path

## Why
After #6 landed, browser startup still calls `SystemExit(1)`, which terminates the MCP server instead of surfacing a tool/runtime error. This is the leftover piece from the closed #7 overlap with #6.

## Validation
- `uv run pytest tests/test_server.py -k 'browser_startup_failure or test_smoke'`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ee85e9d-c27f-4471-a73b-2377f1e87498?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ee85e9d-c27f-4471-a73b-2377f1e87498&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

